### PR TITLE
Fix poetry build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ include = '\.pyi?$'
 
 
 [tool.poetry]
-name = "eav"
+name = "django-eav2"
 description = "Entity-Attribute-Value storage for Django"
 version = "0.14.1"
 license = "GNU Lesser General Public License (LGPL), Version 3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ name = "django-eav2"
 description = "Entity-Attribute-Value storage for Django"
 version = "0.14.1"
 license = "GNU Lesser General Public License (LGPL), Version 3"
+packages = [
+  { include = "eav" }
+]
+
 
 authors = [
   "Mauro Lizaur <mauro@sdf.org>",


### PR DESCRIPTION
When first converted, the package name assigned was set to `eav`, which is incorrect. To build correctly, we need to tell poetry the package is named `django-eav2` and to include the module `eav` in the distribution.