### PR TITLE
Use django_jsonfield_backport for django 2.2 JSONField ; Adds 'test' github action workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: test
+
+'on': [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        django-version:
+          - 'Django~=2.2.0'
+          - 'Django~=3.1.0'
+          - 'Django~=3.2.0'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Set up cache
+        uses: actions/cache@v1
+        with:
+          path: .venv
+          key: venv-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+
+      - name: Install dependencies
+        run: |
+          poetry install
+          poetry run pip install -U pip
+          poetry run pip install -U "${{ matrix.django-version }}"
+
+      - name: Run tests
+        run: |
+          poetry run pytest
+          poetry check
+          poetry run pip check

--- a/eav/migrations/0003_auto_20210404_2209.py
+++ b/eav/migrations/0003_auto_20210404_2209.py
@@ -5,8 +5,8 @@ import eav.fields
 import django.core.serializers.json
 try:
     from django.db.models import JSONField
-except:
-    from django.contrib.postgres.fields import JSONField
+except ImportError:
+    from django_jsonfield_backport.models import JSONField
 
 
 class Migration(migrations.Migration):

--- a/eav/models.py
+++ b/eav/models.py
@@ -14,35 +14,31 @@ from copy import copy
 from django.contrib.contenttypes import fields as generic
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models.base import ModelBase
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from django.core.serializers.json import DjangoJSONEncoder
-if hasattr(models, "JSONField"):
-    JSONField = models.JSONField
-else:
-   try:
-       from django.contrib.postgres.fields import JSONField
-   except:
-       JSONField = models.TextField
+try:
+    from django.db.models import JSONField
+except ImportError:
+    from django_jsonfield_backport.models import JSONField
 
-
+from . import register
+from .exceptions import IllegalAssignmentException
+from .fields import CSVField, EavDatatypeField, EavSlugField
 from .validators import (
-    validate_text,
+    validate_bool,
+    validate_csv,
+    validate_date,
+    validate_enum,
     validate_float,
     validate_int,
-    validate_date,
-    validate_bool,
-    validate_object,
-    validate_enum,
     validate_json,
-    validate_csv,
+    validate_object,
+    validate_text,
 )
-from .exceptions import IllegalAssignmentException
-from .fields import EavDatatypeField, EavSlugField, CSVField
-from . import register
 
 
 class EnumValue(models.Model):

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,7 +29,7 @@ python-versions = "*"
 name = "asgiref"
 version = "3.3.4"
 description = "ASGI specs, helper code, and adapters"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -270,7 +270,7 @@ python-versions = "*"
 name = "django"
 version = "3.2.4"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -282,6 +282,17 @@ sqlparse = ">=0.2.2"
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
+
+[[package]]
+name = "django-jsonfield-backport"
+version = "1.0.4"
+description = "Backport of the cross-DB JSONField model and form fields from Django 3.1."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+Django = ">=2.2"
 
 [[package]]
 name = "doc8"
@@ -1042,7 +1053,7 @@ unidecode = ["Unidecode (>=1.1.1)"]
 name = "pytz"
 version = "2021.1"
 description = "World timezone definitions, modern and historical"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1281,7 +1292,7 @@ test = ["pytest"]
 name = "sqlparse"
 version = "0.4.1"
 description = "A non-validating SQL parser."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -1384,7 +1395,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1477,7 +1488,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "3ef785cae2c99853dd2e720fa770df1b666b82697171e065db74a3e3fde82c0b"
+content-hash = "7673dc291b8e8baa258cefa25cc7770d820d3625d378f1b50d40f5dc80232841"
 
 [metadata.files]
 aiocontextvars = [
@@ -1629,6 +1640,10 @@ distlib = [
 django = [
     {file = "Django-3.2.4-py3-none-any.whl", hash = "sha256:ea735cbbbb3b2fba6d4da4784a0043d84c67c92f1fdf15ad6db69900e792c10f"},
     {file = "Django-3.2.4.tar.gz", hash = "sha256:66c9d8db8cc6fe938a28b7887c1596e42d522e27618562517cc8929eb7e7f296"},
+]
+django-jsonfield-backport = [
+    {file = "django-jsonfield-backport-1.0.4.tar.gz", hash = "sha256:73998c6aa2e0ab1a4f9da4ce62f01576e019147678c881401b02846712069786"},
+    {file = "django_jsonfield_backport-1.0.4-py3-none-any.whl", hash = "sha256:ccb0c47bad0dad400940c9897baa6de956b487299e351821a7a59cc18e7b0f69"},
 ]
 doc8 = [
     {file = "doc8-0.8.1-py2.py3-none-any.whl", hash = "sha256:4d58a5c8c56cedd2b2c9d6e3153be5d956cf72f6051128f0f2255c66227df721"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
+django-jsonfield-backport = "^1.0.4"
 
 [tool.poetry.dev-dependencies]
 django = "^3.2"

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -26,7 +26,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.postgres',
+    'django_jsonfield_backport',
     # Test Project:
     'test_project.apps.TestAppConfig',
     # Our app:


### PR DESCRIPTION
While adding a Github Action workflow to run tests, I noticed there was a requirement for Postgres. With the `django.db.models.JSONField` introduced in django 3.1, rather than go through a whole process of installing Postgres, I figured do it right and use the [django-jsonfield-backport](https://github.com/laymonage/django-jsonfield-backport) package. This was written by the person who wrote the Django 3.1 JSONField, so should be good to go!

Additionally, this adds running pytest for the supported python/django combinations on repo pushes, pull requests, and manual runs.

## Description
* What is the current behavior? You can also link to an open issue here.
* If this is a feature change, what is the new behavior?
* Describe your changes in detail.

## Motivation and Context
* Why is this change required? What problem does it solve?
* If it fixes an open issue, please link to the issue here.

## How Has This Been Tested?
* Did you add appriopriate tests?
* Please describe in detail how you tested your changes.

## Types of Changes
* What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Thank you!
